### PR TITLE
fix: resolve path resolution errors in Vite build

### DIFF
--- a/main.jsx
+++ b/main.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from '@/App.jsx'
-import '@/index.css'
+import App from './App.jsx'
+import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
     <App />


### PR DESCRIPTION
This commit resolves two path resolution errors that were causing the Vite build to fail on Vercel.

The first error was in `index.html`, which was trying to load `main.jsx` from `/src/main.jsx`. This has been corrected to `/main.jsx`.

The second error was in `main.jsx`, which was trying to import `App.jsx` and `index.css` using the `@` alias, which pointed to the `src` directory. The import paths have been changed to relative paths (`./App.jsx` and `./index.css`) to resolve this issue.

This commit also includes previous fixes for the `inotify` build error and adds a `.gitignore` file.